### PR TITLE
use scoped in workers

### DIFF
--- a/src/Core/Presentation/Workers/JoinTimeWorker.cs
+++ b/src/Core/Presentation/Workers/JoinTimeWorker.cs
@@ -1,11 +1,12 @@
 using Application.Logic;
 using Domain.WebServices;
 using Infrastructure.Repositories;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Background;
 
-public sealed class JoinTimeWorker(IJoinTimeWebService joinTimeWebService) : BackgroundService
+public sealed class JoinTimeWorker(IServiceScopeFactory serviceScopeFactory) : BackgroundService
 {
     private const int EXECUTION_INTERVAL = 60000 * 5;
 
@@ -15,6 +16,11 @@ public sealed class JoinTimeWorker(IJoinTimeWebService joinTimeWebService) : Bac
         {
             try
             {
+                using var scope = serviceScopeFactory.CreateScope();
+                
+                var joinTimeWebService =
+                    scope.ServiceProvider.GetRequiredService<IJoinTimeWebService>();
+                    
                 await joinTimeWebService.UpdateOldJoinTimes();
                 await Task.Delay(EXECUTION_INTERVAL, stoppingToken);
             }

--- a/src/Core/Presentation/Workers/LiveCloseWorker.cs
+++ b/src/Core/Presentation/Workers/LiveCloseWorker.cs
@@ -1,11 +1,12 @@
 using Application.Logic;
 using Domain.WebServices;
 using Infrastructure.Repositories;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Background;
 
-public sealed class LiveCloseWorker(ILiveWebService liveWebService) : BackgroundService
+public sealed class LiveCloseWorker(IServiceScopeFactory serviceScopeFactory) : BackgroundService
 {
     private const int EXECUTION_INTERVAL = 60000 * 3;
 
@@ -15,6 +16,11 @@ public sealed class LiveCloseWorker(ILiveWebService liveWebService) : Background
         {
             try
             {
+                using var scope = serviceScopeFactory.CreateScope();
+                
+                var liveWebService =
+                    scope.ServiceProvider.GetRequiredService<ILiveWebService>();
+                    
                 await liveWebService.Close();
                 await Task.Delay(EXECUTION_INTERVAL, stoppingToken);
             }

--- a/src/Core/Presentation/Workers/LiveNotifyWorker.cs
+++ b/src/Core/Presentation/Workers/LiveNotifyWorker.cs
@@ -1,11 +1,12 @@
 using Application.Logic;
 using Domain.WebServices;
 using Infrastructure.Repositories;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Background;
 
-public sealed class LiveNotifyWorker(ILiveWebService liveWebService) : BackgroundService
+public sealed class LiveNotifyWorker(IServiceScopeFactory serviceScopeFactory) : BackgroundService
 {
     private const int EXECUTION_INTERVAL = 60000 * 5;
 
@@ -15,6 +16,11 @@ public sealed class LiveNotifyWorker(ILiveWebService liveWebService) : Backgroun
         {
             try
             {
+                using var scope = serviceScopeFactory.CreateScope();
+                
+                var liveWebService =
+                    scope.ServiceProvider.GetRequiredService<ILiveWebService>();
+
                 await liveWebService.NotifyUpcomingLives();
                 await Task.Delay(EXECUTION_INTERVAL, stoppingToken);
             }

--- a/src/Core/Presentation/Workers/TimeSelectionWorker.cs
+++ b/src/Core/Presentation/Workers/TimeSelectionWorker.cs
@@ -1,11 +1,12 @@
 using Application.Logic;
 using Domain.WebServices;
 using Infrastructure.Repositories;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 
 namespace Background;
 
-public sealed class TimeSelectionWorker(ITimeSelectionWebService timeSelectionWebService)
+public sealed class TimeSelectionWorker(IServiceScopeFactory serviceScopeFactory)
     : BackgroundService
 {
     private const int EXECUTION_INTERVAL = 60000 * 5;
@@ -16,8 +17,14 @@ public sealed class TimeSelectionWorker(ITimeSelectionWebService timeSelectionWe
         {
             try
             {
+                using var scope = serviceScopeFactory.CreateScope();
+                
+                var timeSelectionWebService =
+                    scope.ServiceProvider.GetRequiredService<ITimeSelectionWebService>();
+
                 await timeSelectionWebService.UpdateOldTimeSelections();
                 await timeSelectionWebService.NotifyUpcomingTimeSelectionAndJoinTime();
+
                 await Task.Delay(EXECUTION_INTERVAL, stoppingToken);
             }
             catch (Exception e)


### PR DESCRIPTION
## Descrição
Corrige comportamento de uso de scoped em singleton usando estratégia de IServiceScopeFactory

## Checklist antes de compartilhar o PR no grupo

- [x] Escrevi testes que garantem que minha alteração funciona como esperado
- [x] Executei o comando `dotnet csharpier .` na raiz do projeto
- [x] Garanti que meu código não gera novos warnings ou alertas do Sonar Cloud
- [x] Revisei extensivamente a versão final do meu código analisando as alterações que estão entrando e saindo

