### PR TITLE
LM botao iniciar live apareça após add vídeo

### DIFF
--- a/src/APP.Platform/Pages/Canal/Index.cshtml
+++ b/src/APP.Platform/Pages/Canal/Index.cshtml
@@ -338,8 +338,11 @@
             })
             .then(function (data) {
                 const CONSIDERED_EMPTY = "";
+
                 let videosPrivates = document.querySelector("#savedVideosCanal");
-                  let botIniciarLiveComVideo =   ` 
+                
+                //Botão sem msg de span de "sem vídeos no momento"
+                let botIniciarLiveComVideo =    ` 
                                                       @{  
                                                             if (Model.PerfilOwner?.Id == Model.UserProfile?.Id && Model.IsAuth)
                                                                 {
@@ -357,13 +360,11 @@
                                                                 }
                                                         }
                                                  `
-
+                 //Botão com msg de span "sem vídeos no momento"
                 let botIniciarLiveSemVideo =      ` 
                                                     <div style="justify-content: center; display: flex; flex-direction: column; padding: 20px; color: grey; width: 100%; align-items: center;">
                                                        <span>Sem vídeos no momento</span>
- 
-                                                      @{
-                                                        
+                                                      @{ 
                                                             if (Model.PerfilOwner?.Id == Model.UserProfile?.Id && Model.IsAuth)
                                                                 {
                                                                     <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; width: 100%; margin-top: 1rem;">
@@ -386,7 +387,7 @@
                     && data.liveSchedules === CONSIDERED_EMPTY) {
                     videosPrivates.innerHTML = botIniciarLiveSemVideo
 
-                //caso tiver lives agendadas (concatenação do botão iniciar live + Lives)
+                //caso tiver lives agendadas (concatena botão iniciar live + Vídeos)
                 } else {
                     videosPrivates.innerHTML = botIniciarLiveComVideo+data.liveSchedules+data.privateLives;
 

--- a/src/APP.Platform/Pages/Canal/Index.cshtml
+++ b/src/APP.Platform/Pages/Canal/Index.cshtml
@@ -339,32 +339,56 @@
             .then(function (data) {
                 const CONSIDERED_EMPTY = "";
                 let videosPrivates = document.querySelector("#savedVideosCanal");
+                  let botIniciarLiveComVideo =   ` 
+                                                      @{  
+                                                            if (Model.PerfilOwner?.Id == Model.UserProfile?.Id && Model.IsAuth)
+                                                                {
+                                                                    <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; width: 100%; margin-top: 1rem;">
+                                                                        <a class="material-icons OpenNewButtom"
+                                                                            style="font-size: 36px; cursor: pointer; margin-right: 0px;"
+                                                                            data-bs-toggle="modal"
+                                                                            data-bs-target="#liveModal">
+                                                                            add_circle
+                                                                        </a>
+                                                                        <span style="color: #AEAEAE; font-size: 12px">
+                                                                            Iniciar live
+                                                                        </span>
+                                                                    </div>
+                                                                }
+                                                        }
+                                                 `
 
+                let botIniciarLiveSemVideo =      ` 
+                                                    <div style="justify-content: center; display: flex; flex-direction: column; padding: 20px; color: grey; width: 100%; align-items: center;">
+                                                       <span>Sem vídeos no momento</span>
+ 
+                                                      @{
+                                                        
+                                                            if (Model.PerfilOwner?.Id == Model.UserProfile?.Id && Model.IsAuth)
+                                                                {
+                                                                    <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; width: 100%; margin-top: 1rem;">
+                                                                        <a class="material-icons OpenNewButtom"
+                                                                            style="font-size: 36px; cursor: pointer; margin-right: 0px;"
+                                                                            data-bs-toggle="modal"
+                                                                            data-bs-target="#liveModal">
+                                                                            add_circle
+                                                                        </a>
+                                                                        <span style="color: #AEAEAE; font-size: 12px">
+                                                                            Iniciar live
+                                                                        </span>
+                                                                    </div>
+                                                                }
+                                                        }
+                                                    <div>
+                                                 `
+                //verifica se tem não tem Lives agendadas
                 if (data.privateLives === CONSIDERED_EMPTY
                     && data.liveSchedules === CONSIDERED_EMPTY) {
-                    videosPrivates.innerHTML = `
-                                                    <div style="justify-content: center; display: flex; flex-direction: column; padding: 20px; color: grey; width: 100%; align-items: center;">
-                                                        <span>Sem vídeos no momento</span> @{
-                                                        if (Model.PerfilOwner?.Id == Model.UserProfile?.Id && Model.IsAuth)
-                                                        {
-                                                            <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; width: 100%; margin-top: 1rem;">
+                    videosPrivates.innerHTML = botIniciarLiveSemVideo
 
-                                                            <a class="material-icons OpenNewButtom"
-                                                                style="font-size: 36px; cursor: pointer; margin-right: 0px;"
-                                                                data-bs-toggle="modal"
-                                                                data-bs-target="#liveModal">
-                                                                add_circle
-                                                            </a>
-                                                            <span style="color: #AEAEAE; font-size: 12px">
-                                                                Iniciar live
-                                                                </span>
-                                                            </div>
-                                                        }
-                                                        }
-                                                   <div>
-                                                        `
+                //caso tiver lives agendadas (concatenação do botão iniciar live + Lives)
                 } else {
-                    videosPrivates.innerHTML = data.liveSchedules+data.privateLives;
+                    videosPrivates.innerHTML = botIniciarLiveComVideo+data.liveSchedules+data.privateLives;
 
                 }
 

--- a/src/Core/Presentation/Queues/ChatsQueue.cs
+++ b/src/Core/Presentation/Queues/ChatsQueue.cs
@@ -1,12 +1,12 @@
 using System.Text;
 using System.Text.Json;
 using Application.Logic;
-using Domain.WebServices;
 using Domain.Entities;
-using Microsoft.Extensions.DependencyInjection;
+using Domain.WebServices;
 using Infrastructure;
 using Infrastructure.Repositories;
 using MassTransit;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Background;
 
@@ -17,8 +17,7 @@ public sealed class ChatsQueue(IServiceScopeFactory serviceScopeFactory) : ICons
         try
         {
             using var scope = serviceScopeFactory.CreateScope();
-            var chatWebService =
-                scope.ServiceProvider.GetRequiredService<IChatWebService>();
+            var chatWebService = scope.ServiceProvider.GetRequiredService<IChatWebService>();
 
             var chatMessage = context.Message;
             await chatWebService.Save(chatMessage);

--- a/src/Core/Presentation/Queues/CommentsQueue.cs
+++ b/src/Core/Presentation/Queues/CommentsQueue.cs
@@ -2,11 +2,11 @@ using System.Text;
 using System.Text.Json;
 using Application.Logic;
 using Domain.Entities;
+using Domain.WebServices;
 using Infrastructure;
 using Infrastructure.Repositories;
-using Microsoft.Extensions.DependencyInjection;
 using MassTransit;
-using Domain.WebServices;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace Background;
 
@@ -17,9 +17,8 @@ public sealed class CommentsQueue(IServiceScopeFactory serviceScopeFactory) : IC
         try
         {
             using var scope = serviceScopeFactory.CreateScope();
-            var commentWebService =
-                    scope.ServiceProvider.GetRequiredService<ICommentWebService>();
-                    
+            var commentWebService = scope.ServiceProvider.GetRequiredService<ICommentWebService>();
+
             var content = context.Message;
             await commentWebService.ValidateComment(content);
         }

--- a/src/Core/Presentation/Queues/LiveThumbnailQueue.cs
+++ b/src/Core/Presentation/Queues/LiveThumbnailQueue.cs
@@ -1,21 +1,21 @@
 using System.Text;
 using System.Text.Json;
 using Domain.Contracts;
+using Domain.WebServices;
 using MassTransit;
 using Microsoft.Extensions.DependencyInjection;
-using Domain.WebServices;
 
 namespace Background;
 
-public sealed class LiveThumbnailQueue(IServiceScopeFactory serviceScopeFactory) : IConsumer<LiveThumbnailMessage>
+public sealed class LiveThumbnailQueue(IServiceScopeFactory serviceScopeFactory)
+    : IConsumer<LiveThumbnailMessage>
 {
     public async Task Consume(ConsumeContext<LiveThumbnailMessage> context)
     {
         try
         {
             using var scope = serviceScopeFactory.CreateScope();
-            var liveWebService =
-                    scope.ServiceProvider.GetRequiredService<ILiveWebService>();
+            var liveWebService = scope.ServiceProvider.GetRequiredService<ILiveWebService>();
 
             var request = new UpdateLiveThumbnailRequest(
                 Guid.Parse(context.Message.Id),


### PR DESCRIPTION
## Descrição
Alterado código para que o botão "iniciar live" fique aparecendo após add novo vídeo.
E mensagem de "Sem vídeos no momento" não apareça após add novo vídeo. 
![image](https://github.com/user-attachments/assets/8678d8bf-023b-4513-8f17-e833e7fb253c)

Tela sem vídeos adicionados.
![image](https://github.com/user-attachments/assets/d8317207-d098-4674-9b7c-655a7f2bc3b7)



## Checklist antes de compartilhar o PR no grupo

- [ ] Escrevi testes que garantem que minha alteração funciona como esperado
- [x] Executei o comando `dotnet csharpier .` na raiz do projeto
- [x] Garanti que meu código não gera novos warnings ou alertas do Sonar Cloud
- [x] Revisei extensivamente a versão final do meu código analisando as alterações que estão entrando e saindo

