### PR TITLE
Refactor: Adapts HTTP Request with abstraction for profile entity

### DIFF
--- a/src/APP.Platform/Pages/Busca/Index.cshtml.cs
+++ b/src/APP.Platform/Pages/Busca/Index.cshtml.cs
@@ -54,7 +54,7 @@ public sealed class BuscaIndexModel : CustomPageModel
             return Redirect("index");
         }
 
-        var search = new Search(_context, _httpClientFactory, key);
+        var search = new Search(_context, _httpClientFactory, _perfilWebService, key);
 
         var client = _httpClientFactory.CreateClient("CoreAPI");
 

--- a/src/APP.Platform/Pages/Busca/Search.cs
+++ b/src/APP.Platform/Pages/Busca/Search.cs
@@ -1,5 +1,6 @@
 ﻿using Domain.Entities;
 using Domain.Models.ViewModels;
+using Domain.WebServices;
 using Infrastructure.Data.Contexts;
 
 namespace APP.Platform.Pages
@@ -8,19 +9,21 @@ namespace APP.Platform.Pages
     {
         private readonly ApplicationDbContext _context;
         private readonly PerfilDbContext _perfilContext;
+        private IPerfilWebService _perfilWebService { get; set; }
         public List<Live> Lives = new List<Live>();
-        public List<Domain.Entities.Perfil> Perfils = new List<Domain.Entities.Perfil>();
-
+        public List<Domain.Entities.Perfil> Perfils = new();
         public IHttpClientFactory _httpClientFactory { get; set; }
 
         public Search(
             ApplicationDbContext context,
             IHttpClientFactory httpClientFactory,
+            IPerfilWebService perfilWebService,
             string key
         )
         {
             _httpClientFactory = httpClientFactory;
             _context = context;
+            _perfilWebService = perfilWebService;
 
             foreach (var word in key.Trim().Split(' '))
             {
@@ -39,19 +42,27 @@ namespace APP.Platform.Pages
 
         public async Task ProcessKeywordForChannels(string keyword)
         {
-            var client = _httpClientFactory.CreateClient("CoreAPI");
+            var perfilsResponse = await _perfilWebService.GetByKeyword(keyword);
 
-            using var responseTask = await client.GetAsync("api/perfils/Contains/" + keyword);
-
-            if (!responseTask.IsSuccessStatusCode)
+            foreach (var perfil in perfilsResponse)
             {
-                return;
+                var perfilLegacy = new Domain.Entities.Perfil
+                {
+                    Id = perfil.Id,
+                    Nome = perfil.Nome,
+                    Foto = perfil.Foto,
+                    Token = perfil.Token,
+                    UserName = perfil.UserName,
+                    Linkedin = perfil.Linkedin,
+                    GitHub = perfil.GitHub,
+                    Bio = perfil.Bio,
+                    Email = perfil.Email,
+                    Descricao = perfil.Descricao,
+                    Experiencia = (Domain.Entities.ExperienceLevel)perfil.Experiencia
+                };
+                Perfils.Add(perfilLegacy);
             }
-            var perfils = await responseTask.Content.ReadFromJsonAsync<
-                List<Domain.Entities.Perfil>
-            >();
 
-            Perfils.AddRange(perfils);
             foreach (var perfil in Perfils)
             {
                 Lives.AddRange(SearchByUserId(perfil.Id));

--- a/src/APP.Platform/Pages/Canal/Editor/Index.cshtml.cs
+++ b/src/APP.Platform/Pages/Canal/Editor/Index.cshtml.cs
@@ -2,6 +2,7 @@
 using Domain.Entities;
 using Domain.Enums;
 using Domain.Models.ViewModels;
+using Domain.WebServices;
 using Infrastructure.Data.Contexts;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -34,6 +35,7 @@ public sealed class EditorIndexModel : CustomPageModel
     public bool IsUsrCanal { get; set; }
 
     public Domain.Entities.Perfil? Perfil { get; set; }
+    private IPerfilWebService _perfilWebService { get; set; }
 
     public Dictionary<string, List<string>> RelatioTags { get; set; }
 
@@ -41,12 +43,14 @@ public sealed class EditorIndexModel : CustomPageModel
         ApplicationDbContext context,
         IHttpClientFactory httpClientFactory,
         IHttpContextAccessor httpContextAccessor,
+        IPerfilWebService perfilWebService,
         Settings settings
     )
         : base(context, httpClientFactory, httpContextAccessor, settings)
     {
         _httpClientFactory = httpClientFactory;
         _context = context;
+        _perfilWebService = perfilWebService;
 
         RelatioTags = DataTags.GetTags();
     }
@@ -72,9 +76,21 @@ public sealed class EditorIndexModel : CustomPageModel
                 return Redirect("../");
             }
 
-            using var byIdResponse = await client.GetAsync($"api/perfils/" + live.PerfilId);
-
-            var owner = await byIdResponse.Content.ReadFromJsonAsync<Domain.Entities.Perfil>();
+            var perfilResponse = await _perfilWebService.GetById(live.PerfilId);
+            var owner = new Domain.Entities.Perfil
+            {
+                Id = perfilResponse.Id,
+                Nome = perfilResponse.Nome,
+                Foto = perfilResponse.Foto,
+                Token = perfilResponse.Token,
+                UserName = perfilResponse.UserName,
+                Linkedin = perfilResponse.Linkedin,
+                GitHub = perfilResponse.GitHub,
+                Bio = perfilResponse.Bio,
+                Email = perfilResponse.Email,
+                Descricao = perfilResponse.Descricao,
+                Experiencia = (Domain.Entities.ExperienceLevel)perfilResponse.Experiencia
+            };
 
             if (owner != null && owner.Id != live.PerfilId)
             {

--- a/src/APP.Platform/Pages/Canal/Index.cshtml.cs
+++ b/src/APP.Platform/Pages/Canal/Index.cshtml.cs
@@ -85,26 +85,30 @@ public sealed class CanalIndexModel : CustomPageModel
             return Redirect("../Perfil");
         }
 
-        var client = _httpClientFactory.CreateClient("CoreAPI");
-        using var responseTask = await client.GetAsync("api/perfils/ByUsername/" + usr);
+        var perfilResponse = await _perfilWebService.GetByUsername(usr);
 
-        var perfilOwner = await responseTask.Content.ReadFromJsonAsync<Domain.Entities.Perfil>();
-
-        if (perfilOwner == null)
+        var perfilOwner = new Domain.Entities.Perfil
         {
-            return Redirect("../Index");
-        }
+            Id = perfilResponse.Id,
+            Nome = perfilResponse.Nome,
+            Foto = perfilResponse.Foto,
+            Token = perfilResponse.Token,
+            UserName = perfilResponse.UserName,
+            Linkedin = perfilResponse.Linkedin,
+            GitHub = perfilResponse.GitHub,
+            Bio = perfilResponse.Bio,
+            Email = perfilResponse.Email,
+            Descricao = perfilResponse.Descricao,
+            Experiencia = (Domain.Entities.ExperienceLevel)perfilResponse.Experiencia
+        };
+
         PerfilOwner = perfilOwner;
 
-        if (UserProfile != null)
-        {
-            IsFollowing = await _followService.IsFollowingAsync(UserProfile.Id, perfilOwner.Id);
-        }
+        var client = _httpClientFactory.CreateClient("CoreAPI");
 
         using var responseTaskFollow = await client.GetAsync(
             $"api/follow/getFollowInformation/{perfilOwner.Id}"
         );
-
         responseTaskFollow.EnsureSuccessStatusCode();
 
         var followInformation =
@@ -118,10 +122,22 @@ public sealed class CanalIndexModel : CustomPageModel
 
     public async Task<ActionResult> OnGetAfterloadCanal(string usr)
     {
-        var client = _httpClientFactory.CreateClient("CoreAPI");
-        using var responseTask = await client.GetAsync("api/perfils/ByUsername/" + usr);
+        var perfilResponse = await _perfilWebService.GetByUsername(usr);
 
-        var perfilOwner = await responseTask.Content.ReadFromJsonAsync<Domain.Entities.Perfil>();
+        var perfilOwner = new Domain.Entities.Perfil
+        {
+            Id = perfilResponse.Id,
+            Nome = perfilResponse.Nome,
+            Foto = perfilResponse.Foto,
+            Token = perfilResponse.Token,
+            UserName = perfilResponse.UserName,
+            Linkedin = perfilResponse.Linkedin,
+            GitHub = perfilResponse.GitHub,
+            Bio = perfilResponse.Bio,
+            Email = perfilResponse.Email,
+            Descricao = perfilResponse.Descricao,
+            Experiencia = (Domain.Entities.ExperienceLevel)perfilResponse.Experiencia
+        };
 
         if (perfilOwner == null)
         {
@@ -317,15 +333,28 @@ public sealed class CanalIndexModel : CustomPageModel
 
         await GetMyEvents();
 
-        var client = _httpClientFactory.CreateClient("CoreAPI");
-        using var responseTask = await client.GetAsync("api/perfils/" + id);
+        var perfilResponse = await _perfilWebService.GetById(id);
 
-        var perfil = await responseTask.Content.ReadFromJsonAsync<Domain.Entities.Perfil>();
+        var perfil = new Domain.Entities.Perfil
+        {
+            Id = perfilResponse.Id,
+            Nome = perfilResponse.Nome,
+            Foto = perfilResponse.Foto,
+            Token = perfilResponse.Token,
+            UserName = perfilResponse.UserName,
+            Linkedin = perfilResponse.Linkedin,
+            GitHub = perfilResponse.GitHub,
+            Bio = perfilResponse.Bio,
+            Email = perfilResponse.Email,
+            Descricao = perfilResponse.Descricao,
+            Experiencia = (Domain.Entities.ExperienceLevel)perfilResponse.Experiencia
+        };
 
-        if (responseTask.StatusCode != HttpStatusCode.OK || perfil == null)
+        if (perfil == null)
         {
             return BadRequest();
         }
+
         PerfilOwner = perfil;
         HashSet<TimeSelection> valueSet = new HashSet<TimeSelection>(MyEvents!.Values);
 
@@ -400,10 +429,29 @@ public sealed class CanalIndexModel : CustomPageModel
             .TimeSelections.Where(e => e.Id == JoinTime.TimeSelectionId)
             .FirstOrDefault();
 
-        var client = _httpClientFactory.CreateClient("CoreAPI");
-        using var byIdResponse = await client.GetAsync($"api/perfils/" + timeSelection?.PerfilId);
-        var channelUserName =
-            await byIdResponse.Content.ReadFromJsonAsync<Domain.Entities.Perfil>();
+        var perfilResponse = await _perfilWebService.GetById((Guid)(timeSelection?.PerfilId));
+
+        var perfil = new Domain.Entities.Perfil
+        {
+            Id = perfilResponse.Id,
+            Nome = perfilResponse.Nome,
+            Foto = perfilResponse.Foto,
+            Token = perfilResponse.Token,
+            UserName = perfilResponse.UserName,
+            Linkedin = perfilResponse.Linkedin,
+            GitHub = perfilResponse.GitHub,
+            Bio = perfilResponse.Bio,
+            Email = perfilResponse.Email,
+            Descricao = perfilResponse.Descricao,
+            Experiencia = (Domain.Entities.ExperienceLevel)perfilResponse.Experiencia
+        };
+
+        if (perfil == null)
+        {
+            return BadRequest();
+        }
+
+        var channelUserName = perfil.UserName;
 
         if (UserProfile.Id == Guid.Empty)
         {

--- a/src/APP.Platform/Pages/Notificacoes/Index.cshtml.cs
+++ b/src/APP.Platform/Pages/Notificacoes/Index.cshtml.cs
@@ -4,7 +4,6 @@ using Domain.WebServices;
 using Infrastructure.Data.Contexts;
 using Microsoft.AspNetCore.Mvc;
 
-
 namespace APP.Platform.Pages
 {
     public sealed class NotificacoesModel(
@@ -14,7 +13,7 @@ namespace APP.Platform.Pages
         Settings settings,
         IPerfilWebService _perfilWebService,
         INotificationWebService _notificationWebService
-        ) : CustomPageModel(_context, _httpClientFactory, httpContextAccessor, settings)
+    ) : CustomPageModel(_context, _httpClientFactory, httpContextAccessor, settings)
     {
         public List<NotificationViewModel>? Notifications { get; set; }
 

--- a/src/APP.Platform/Pages/ScheduleActions/index.cshtml.cs
+++ b/src/APP.Platform/Pages/ScheduleActions/index.cshtml.cs
@@ -851,14 +851,26 @@ namespace APP.Platform.Pages.ScheduleActions
 
         public async Task<IActionResult> OnGetAcceptance(string id)
         {
-#warning se vem o id do front, provavelmente os dados buscados aqui ja estão disponiveis la
+#warning se vem o id(token) do front, provavelmente os dados buscados aqui ja estão disponiveis la
 
-            var client = _httpClientFactory.CreateClient("CoreAPI");
-            using var byIdResponse = await client.GetAsync($"api/perfils/" + id);
+            var perfilResponse = await _perfilWebService.GetByToken(id);
 
-            var result = await byIdResponse.Content.ReadFromJsonAsync<Domain.Entities.Perfil>();
+            var perfilLegacy = new Domain.Entities.Perfil
+            {
+                Id = perfilResponse.Id,
+                Nome = perfilResponse.Nome,
+                Foto = perfilResponse.Foto,
+                Token = perfilResponse.Token,
+                UserName = perfilResponse.UserName,
+                Linkedin = perfilResponse.Linkedin,
+                GitHub = perfilResponse.GitHub,
+                Bio = perfilResponse.Bio,
+                Email = perfilResponse.Email,
+                Descricao = perfilResponse.Descricao,
+                Experiencia = (Domain.Entities.ExperienceLevel)perfilResponse.Experiencia
+            };
 
-            return new JsonResult(result);
+            return new JsonResult(perfilLegacy);
         }
 
         public async Task<IActionResult> OnPostSetAluno(Guid joinId)


### PR DESCRIPTION
## Descrição
alterei
Incorporei a abstração perfilwebservice segue o exemplo:
![Screenshot_471](https://github.com/user-attachments/assets/70a8907c-6977-4906-aee7-7d37643b88e9)

nos  lugares que estão acessando os end-points de perfil diretamente via httpClient segue o exemplo:
![httpClientFactory](https://github.com/user-attachments/assets/c24e8eac-b022-450e-9a75-6931c82d3bf3)
 




## Checklist antes de compartilhar o PR no grupo

- [x] Escrevi testes que garantem que minha alteração funciona como esperado
- [x] Executei o comando `dotnet csharpier .` na raiz do projeto
- [ ] Garanti que meu código não gera novos warnings ou alertas do Sonar Cloud
- [x] Revisei extensivamente a versão final do meu código analisando as alterações que estão entrando e saindo

