### PR TITLE
Lm hotfix tornar nova live canal direto html

### DIFF
--- a/src/APP.Platform/Pages/Canal/Index.cshtml
+++ b/src/APP.Platform/Pages/Canal/Index.cshtml
@@ -175,6 +175,32 @@
     </ul>
     <div class="tab-content" id="myTabContent">
         <div class="tab-pane fade show active" id="my-videos" role="tabpanel" aria-labelledby="my-videos-tab">
+
+      @* div inicia oculta e após verificação aparece na tela *@
+         <div id="msgSemVideoNoMomento" style="display: none;">
+                 <div style="justify-content: center; display: flex; flex-direction: column; padding: 20px; color: grey; width: 100%; align-items: center;">
+                      <span>Sem vídeos no momento</span>
+                 </div>                                      
+         </div>
+        
+        @* div do botão adicionar nova live *@
+         <div id="botIniciarLive">
+            @{  
+               if (Model.PerfilOwner?.Id == Model.UserProfile?.Id && Model.IsAuth)
+                     {
+                         <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; width: 100%; margin-top: 1rem;">
+                              <a class="material-icons OpenNewButtom"
+                                   style="font-size: 36px; cursor: pointer; margin-right: 0px;"
+                                   data-bs-toggle="modal"
+                                   data-bs-target="#liveModal">
+                                     add_circle
+                              </a>
+                                <span style="color: #AEAEAE; font-size: 12px">Iniciar live</span>
+                         </div>
+                      }
+                }
+         </div>
+
             <main class="videos-group" id="savedVideosCanal">
                 <div class="d-flex justify-content-center">
                     <div class="spinner-grow" role="status">
@@ -251,6 +277,7 @@
             flex-wrap: wrap;
             min-height: 120px;
         }
+
     </style>
 
 
@@ -339,57 +366,21 @@
             .then(function (data) {
                 const CONSIDERED_EMPTY = "";
 
+                let msgSemVideo = document.querySelector("#msgSemVideoNoMomento");
                 let videosPrivates = document.querySelector("#savedVideosCanal");
                 
-                //Botão sem msg de span de "sem vídeos no momento"
-                let botIniciarLiveComVideo =    ` 
-                                                      @{  
-                                                            if (Model.PerfilOwner?.Id == Model.UserProfile?.Id && Model.IsAuth)
-                                                                {
-                                                                    <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; width: 100%; margin-top: 1rem;">
-                                                                        <a class="material-icons OpenNewButtom"
-                                                                            style="font-size: 36px; cursor: pointer; margin-right: 0px;"
-                                                                            data-bs-toggle="modal"
-                                                                            data-bs-target="#liveModal">
-                                                                            add_circle
-                                                                        </a>
-                                                                        <span style="color: #AEAEAE; font-size: 12px">
-                                                                            Iniciar live
-                                                                        </span>
-                                                                    </div>
-                                                                }
-                                                        }
-                                                 `
-                 //Botão com msg de span "sem vídeos no momento"
-                let botIniciarLiveSemVideo =      ` 
-                                                    <div style="justify-content: center; display: flex; flex-direction: column; padding: 20px; color: grey; width: 100%; align-items: center;">
-                                                       <span>Sem vídeos no momento</span>
-                                                      @{ 
-                                                            if (Model.PerfilOwner?.Id == Model.UserProfile?.Id && Model.IsAuth)
-                                                                {
-                                                                    <div style="display: flex; flex-direction: column; justify-content: center; align-items: center; width: 100%; margin-top: 1rem;">
-                                                                        <a class="material-icons OpenNewButtom"
-                                                                            style="font-size: 36px; cursor: pointer; margin-right: 0px;"
-                                                                            data-bs-toggle="modal"
-                                                                            data-bs-target="#liveModal">
-                                                                            add_circle
-                                                                        </a>
-                                                                        <span style="color: #AEAEAE; font-size: 12px">
-                                                                            Iniciar live
-                                                                        </span>
-                                                                    </div>
-                                                                }
-                                                        }
-                                                    <div>
-                                                 `
-                //verifica se tem não tem Lives agendadas
+                //verifica se não tem vídeos adicionados
                 if (data.privateLives === CONSIDERED_EMPTY
                     && data.liveSchedules === CONSIDERED_EMPTY) {
-                    videosPrivates.innerHTML = botIniciarLiveSemVideo
+                    // mostra msg "Sem vídeos no momento na tela"
+                    msgSemVideo.style.display = "block";
 
-                //caso tiver lives agendadas (concatena botão iniciar live + Vídeos)
+                //caso tenha vídeos adicionados
                 } else {
-                    videosPrivates.innerHTML = botIniciarLiveComVideo+data.liveSchedules+data.privateLives;
+                     // oculta msg "Sem vídeos no momento"
+                     msgSemVideo.style.display = "none";
+                     // mostra vídeos adicionadas
+                    videosPrivates.innerHTML = data.liveSchedules+data.privateLives;
 
                 }
 

--- a/src/APP.Platform/Pages/Notificacoes/Index.cshtml.cs
+++ b/src/APP.Platform/Pages/Notificacoes/Index.cshtml.cs
@@ -4,7 +4,6 @@ using Domain.WebServices;
 using Infrastructure.Data.Contexts;
 using Microsoft.AspNetCore.Mvc;
 
-
 namespace APP.Platform.Pages
 {
     public sealed class NotificacoesModel(
@@ -14,7 +13,7 @@ namespace APP.Platform.Pages
         Settings settings,
         IPerfilWebService _perfilWebService,
         INotificationWebService _notificationWebService
-        ) : CustomPageModel(_context, _httpClientFactory, httpContextAccessor, settings)
+    ) : CustomPageModel(_context, _httpClientFactory, httpContextAccessor, settings)
     {
         public List<NotificationViewModel>? Notifications { get; set; }
 


### PR DESCRIPTION
## Descrição
Foi criado duas divs, uma para conter a msg "Sem vídeos no momento" que inicia com display none "oculta" e a outra div com o botão "iniciar live".
![image](https://github.com/user-attachments/assets/da46d774-a155-4e0e-b4cd-86de71bbdee1)

Aqui é feita a verificação se contém vídeos adicionados ou não e trocar display none por block e mostrar a msg na tela.
![image](https://github.com/user-attachments/assets/107d3d27-1c96-4780-b7f5-52d31ebfb8a8)

Ficou assim sem vídeo adicionado e com vídeos
![image](https://github.com/user-attachments/assets/ce597183-a56f-49e0-a990-dc7a62988907)
![image](https://github.com/user-attachments/assets/0cfe08f5-592d-4c38-9917-90608f867c05)

## Checklist antes de compartilhar o PR no grupo

- [ ] Escrevi testes que garantem que minha alteração funciona como esperado
- [x] Executei o comando `dotnet csharpier .` na raiz do projeto
- [x] Garanti que meu código não gera novos warnings ou alertas do Sonar Cloud
- [x] Revisei extensivamente a versão final do meu código analisando as alterações que estão entrando e saindo

