### PR TITLE
Fix style bug by adding missing closing 'div' tag

### DIFF
--- a/src/APP.Platform/Pages/Components/ScheduleActions/_VerAjudasDisponiveis.cshtml
+++ b/src/APP.Platform/Pages/Components/ScheduleActions/_VerAjudasDisponiveis.cshtml
@@ -104,6 +104,7 @@
                         <div style="text-align: right; font-size: 32px; cursor : pointer">
                             <span id="groupHelp-left" class="arrow-icon"><i class="bi bi-arrow-left"></i></span>
                             <span id="groupHelp-right" class="arrow-icon"><i class="bi bi-arrow-right"></i></span>
+												</div>
                         <div id="pedidosPanel" style="display: flex;justify-content: center; flex-wrap:wrap">
                             <div class="d-flex justify-content-center" id="pedidosLoading">
                                 <div class="spinner-grow" role="status">
@@ -174,7 +175,7 @@
         vertical-align: middle; /* Alinha verticalmente ao centro */
         margin: 0 5px; /* Adiciona um pequeno espaço entre as setas e outros elementos */
     }
-    
+
     /* Cor para hover */
     .bi-arrow-left:hover, .bi-arrow-right:hover {
         color: #437AE2;


### PR DESCRIPTION
## Descrição
Adicionei o fechamento da tag "div" que estava faltando, fazendo com o que elemento card herdasse os estilos de alinhamento de texto da mesma

Antes:
![image](https://github.com/user-attachments/assets/c5cff9a2-c312-4019-862e-b394efdbd6c3)

Depois:
![image](https://github.com/user-attachments/assets/ec270910-7e06-4f44-8fa7-00557e486de8)

## Checklist antes de compartilhar o PR no grupo

- [ ] Escrevi testes que garantem que minha alteração funciona como esperado
- [x] Executei o comando `dotnet csharpier .` na raiz do projeto
- [x] Garanti que meu código não gera novos warnings ou alertas do Sonar Cloud
- [x] Revisei extensivamente a versão final do meu código analisando as alterações que estão entrando e saindo

