### PR TITLE
Refactor: adicionando declaração a duas variaveis que estavam como any (finalM e FinalH)

### DIFF
--- a/src/APP.Platform/wwwroot/js/timePickerFlow.js
+++ b/src/APP.Platform/wwwroot/js/timePickerFlow.js
@@ -376,8 +376,8 @@ function displayTotalTime() {
     parseInt(lastPickerMinutesInput.value) -
     parseInt(firstPickerMinutesInput.value);
   const totalTime = deltaH * 60 + deltaM;
-  finalM = totalTime % 60;
-  finalH = (totalTime - finalM) / 60;
+  const finalM = totalTime % 60;
+  const finalH = (totalTime - finalM) / 60;
   if (totalTime > 120) {
     showMessage("Não é possível criar um evento com mais de duas horas.", true);
     displayTimeAlert.innerHTML =


### PR DESCRIPTION
foi adicionando a declaração const a duas variáveis que estavam como any
antes :
![Screenshot_484](https://github.com/user-attachments/assets/e7d9de90-c409-466c-a3e6-dcbbaeabb002)

depois
![Screenshot_485](https://github.com/user-attachments/assets/8fed0eb1-5161-4517-94e8-0505930c3e19)


## Checklist antes de compartilhar o PR no grupo

- [x] Escrevi testes que garantem que minha alteração funciona como esperado
- [x] Executei o comando `dotnet csharpier .` na raiz do projeto
- [x] Garanti que meu código não gera novos warnings ou alertas do Sonar Cloud
- [x] Revisei extensivamente a versão final do meu código analisando as alterações que estão entrando e saindo

