### PR TITLE
Substituindo Forma de Salavar Imagem.

### DIFF
--- a/src/Core/Presentation/EndPoints/PerfilsEndPoints.cs
+++ b/src/Core/Presentation/EndPoints/PerfilsEndPoints.cs
@@ -1,5 +1,6 @@
 using Application.Logic;
 using Domain.Contracts;
+using Infrastructure.FileHandling;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -61,7 +62,8 @@ public static class PerfilsEndPoints
     public static async Task<IResult> UpdateFoto(
         [FromServices] IPerfilBusinessLogic _logic,
         Guid id,
-        IFormFile file
+        IFormFile file,
+        ISaveFile saveFile
     )
     {
         if (!file.ContentType.ToLower().StartsWith("image/", StringComparison.Ordinal))
@@ -69,17 +71,10 @@ public static class PerfilsEndPoints
             return Results.BadRequest("O arquivo enviado não é uma imagem.");
         }
         try
-        {
-#warning esse processo deveria passar por um bl e um repository
-
-            if (!Directory.Exists(Path.Combine("shared", "profile")))
-            {
-                Directory.CreateDirectory(Path.Combine("shared", "profile"));
-            }
+        {       
             var uniqueFileName = Guid.NewGuid() + Path.GetExtension(file.FileName);
-            var filePath = Path.Combine("shared", "profile", uniqueFileName);
-            using var stream = new FileStream(filePath, FileMode.Create);
-            await file.CopyToAsync(stream);
+            var filePath = saveFile.BuildPathFileSave(uniqueFileName, "profile");
+            await saveFile.SaveImageFile(file, filePath);
 
             await _logic.UpdateFotoPerfil(id, filePath);
             return Results.Ok();

--- a/tests/Perfil/PerfilEndPointsTests.cs
+++ b/tests/Perfil/PerfilEndPointsTests.cs
@@ -3,6 +3,7 @@ using Domain.Contracts;
 using Domain.Entities;
 using Domain.Enumerables;
 using Domain.Enums;
+using Infrastructure.FileHandling;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Mvc;
@@ -156,11 +157,13 @@ public class PerfilsEndPointsTests
         fileMock.Setup(_ => _.ContentType).Returns("image/jpeg");
         var file = fileMock.Object;
 
+        var mockSaveFile = new Mock<ISaveFile>();
+
         mockLogic
             .Setup(logic => logic.UpdateFotoPerfil(id, It.IsAny<string>()))
             .Returns(Task.CompletedTask);
 
-        var result = await PerfilsEndPoints.UpdateFoto(mockLogic.Object, id, file);
+        var result = await PerfilsEndPoints.UpdateFoto(mockLogic.Object, id, file,mockSaveFile.Object);
 
         Assert.IsType<Ok>(result);
     }
@@ -254,8 +257,9 @@ public class PerfilsEndPointsTests
         file.Setup(f => f.ContentType).Returns("application/pdf"); // Set a non-image content type
         var id = Guid.NewGuid();
 
+        var mockSaveFile = new Mock<ISaveFile>();
         // Act
-        var result = await PerfilsEndPoints.UpdateFoto(mockLogic.Object, id, file.Object);
+        var result = await PerfilsEndPoints.UpdateFoto(mockLogic.Object, id, file.Object, mockSaveFile.Object);
 
         // Assert
         Assert.IsType<BadRequest<string>>(result);
@@ -271,12 +275,17 @@ public class PerfilsEndPointsTests
         file.Setup(f => f.ContentType).Returns("image/png"); // Set an image content type
         var id = Guid.NewGuid();
 
+        var mockSaveFile = new Mock<ISaveFile>();
+
         mockLogic
             .Setup(logic => logic.UpdateFotoPerfil(id, It.IsAny<string>()))
             .ThrowsAsync(new Exception("Erro durante a atualização da foto"));
 
+        
         // Act
-        var result = await PerfilsEndPoints.UpdateFoto(mockLogic.Object, id, file.Object);
+        var result = await PerfilsEndPoints.UpdateFoto(mockLogic.Object, id, file.Object, mockSaveFile.Object);
+
+
 
         // Assert
         Assert.IsType<BadRequest<string>>(result);


### PR DESCRIPTION
## Descrição
Atualização Upload de foto do usuário foi necessario corrigir na classe EndPointUpload de foto para corrigir o caminho de upload.

## Checklist antes de compartilhar o PR no grupo



- [x] Executei o comando `dotnet csharpier .` na raiz do projeto
- [x] Garanti que meu código não gera novos warnings ou alertas do Sonar Cloud
- [x] Revisei extensivamente a versão final do meu código analisando as alterações que estão entrando e saindo

