### PR TITLE
Test: criacao de testes para LiveNotifyWorker

### DIFF
--- a/tests/Live/LiveNotifyWorkerTest.cs
+++ b/tests/Live/LiveNotifyWorkerTest.cs
@@ -1,0 +1,54 @@
+
+using Background;
+using Domain.WebServices;
+using Microsoft.Extensions.DependencyInjection;
+using Moq;
+using static Azure.Core.HttpHeader;
+
+namespace tests;
+
+public class LiveNotifyWorkerTest
+{
+    [Fact]
+    public async Task StartAsync_ShouldCall_NotifyUpcomingLives()
+    {
+        var mockLiveWebService = new Mock<ILiveWebService>();
+        var mockServiceScopeFactory = new Mock<IServiceScopeFactory>();
+        var mockServiceScope = new Mock<IServiceScope>();
+        var mockServiceProvider = new Mock<IServiceProvider>();
+
+        mockServiceScopeFactory.Setup(x => x.CreateScope()).Returns(mockServiceScope.Object);        
+        mockServiceScope.Setup(x => x.ServiceProvider).Returns(mockServiceProvider.Object);
+        mockServiceProvider.Setup(x => x.GetService(typeof(ILiveWebService))).Returns(mockLiveWebService.Object);
+
+        var liveNotifyWorkerSimulation = new LiveNotifyWorker(mockServiceScopeFactory.Object);
+        const int EXECUTION_INTERVAL = 100;
+        var cancellationTokenSource = new CancellationTokenSource(EXECUTION_INTERVAL);
+        
+        await liveNotifyWorkerSimulation.StartAsync(cancellationTokenSource.Token);        
+        mockLiveWebService.Verify(x => x.NotifyUpcomingLives(), Times.AtLeastOnce());
+    }
+
+
+    [Fact]
+    public async Task StartAsync_ShouldCall_NotifyUpcomingLives_Exceptions()
+    {
+        var mockLiveWebService = new Mock<ILiveWebService>();
+        var mockServiceScopeFactory = new Mock<IServiceScopeFactory>();
+        var mockServiceScope = new Mock<IServiceScope>();
+        var mockServiceProvider = new Mock<IServiceProvider>();
+
+        mockLiveWebService.Setup(x => x.NotifyUpcomingLives()).ThrowsAsync(new Exception("teste exception"));
+        mockServiceScopeFactory.Setup(x => x.CreateScope()).Returns(mockServiceScope.Object);
+        mockServiceScope.Setup(x => x.ServiceProvider).Returns(mockServiceProvider.Object);
+        mockServiceProvider.Setup(x => x.GetService(typeof(ILiveWebService))).Returns(mockLiveWebService.Object);
+
+        var liveNotifyWorkerSimulation = new LiveNotifyWorker(mockServiceScopeFactory.Object);        
+        const int EXECUTION_INTERVAL = 100;
+        var cancellationTokenSource = new CancellationTokenSource(EXECUTION_INTERVAL);    
+        var exception = await Record.ExceptionAsync(() => liveNotifyWorkerSimulation.StartAsync(cancellationTokenSource.Token));
+    
+        Assert.Null(exception); 
+    }
+
+}


### PR DESCRIPTION
## Descrição
Criação de testes para LiveNotifyWorker
Foi criado 2 testes sendo um para chamada do método e outra simulando exception

## Checklist antes de compartilhar o PR no grupo

- [x] Escrevi testes que garantem que minha alteração funciona como esperado
- [x] Executei o comando `dotnet csharpier .` na raiz do projeto
- [x] Garanti que meu código não gera novos warnings ou alertas do Sonar Cloud
- [x] Revisei extensivamente a versão final do meu código analisando as alterações que estão entrando e saindo

