### PR TITLE
Feita correção erro ao add vídeos agendados

### DIFF
--- a/src/APP.Platform/Pages/Canal/Index.cshtml
+++ b/src/APP.Platform/Pages/Canal/Index.cshtml
@@ -535,11 +535,8 @@
                 loadingPaginacao.style.display = "none";
 
                 //verifica se não tem vídeos adicionados
-                if (data.privateLives === CONSIDERED_EMPTY
-                    && data.liveSchedules === CONSIDERED_EMPTY) {
-                    // mostra msg "Sem vídeos no momento na tela"
-                    msgSemVideo.style.display = "block";
-                //caso tenha vídeos adicionados
+                if (data.privateLives === CONSIDERED_EMPTY) {
+
                 } else {
                      // oculta msg "Sem vídeos no momento"
                      msgSemVideo.style.display = "none";

--- a/src/APP.Platform/Pages/Canal/Index.cshtml.cs
+++ b/src/APP.Platform/Pages/Canal/Index.cshtml.cs
@@ -100,7 +100,7 @@ public sealed class CanalIndexModel : CustomPageModel
         };
 
         PerfilOwner = perfilOwner;
-        #warning deve popular IsFollowing
+#warning deve popular IsFollowing
         var client = _httpClientFactory.CreateClient("CoreAPI");
 
         using var responseTaskFollow = await client.GetAsync(
@@ -121,7 +121,7 @@ public sealed class CanalIndexModel : CustomPageModel
         string usr,
         bool isPrivate,
         int pageNumber = 1,
-        int pageSize = 3
+        int pageSize = 9
     )
     {
         var perfilResponse = await _perfilWebService.GetByUsername(usr);

--- a/src/APP.Platform/Pages/ScheduleActions/index.cshtml.cs
+++ b/src/APP.Platform/Pages/ScheduleActions/index.cshtml.cs
@@ -887,7 +887,7 @@ namespace APP.Platform.Pages.ScheduleActions
 
         public async Task<IActionResult> OnGetAcceptance(Guid id)
         {
-            #warning se vem o id(token) do front, provavelmente os dados buscados aqui ja estão disponiveis la
+#warning se vem o id(token) do front, provavelmente os dados buscados aqui ja estão disponiveis la
             var perfilResponse = await _perfilWebService.GetById(id);
 
             var perfilLegacy = new Domain.Entities.Perfil


### PR DESCRIPTION
## Descrição

Após add um novo vídeo agendado a funcionalidade do scroll infinito dava erro e ficava recarregando e chamando a função novamente em loop. Foi retirado data.liveSchedules === CONSIDERED_EMPTY do if para corrigir esse problema.

## Checklist antes de compartilhar o PR no grupo

- [ ] Escrevi testes que garantem que minha alteração funciona como esperado
- [x] Executei o comando `dotnet csharpier .` na raiz do projeto
- [x] Garanti que meu código não gera novos warnings ou alertas do Sonar Cloud
- [x] Revisei extensivamente a versão final do meu código analisando as alterações que estão entrando e saindo

